### PR TITLE
Replaced variable_get with config_get

### DIFF
--- a/config/views_aggregator.settings.json
+++ b/config/views_aggregator.settings.json
@@ -1,0 +1,6 @@
+{
+    "_config_name": "views_aggregator.settings",
+    "views_aggregator_def_precision": 2,
+    "views_aggregator_def_decimal": ".",
+    "views_aggregator_def_separator": ","
+}

--- a/views_aggregator.install
+++ b/views_aggregator.install
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @file
+ * Install, update and uninstall functions for the views_aggregator module.
+ */
+
+/** 
+ * Adds new config file with special configurations to the active config directory
+ */
+function views_aggregator_update_1102() {
+  config_install_default_config('views_aggregator');
+}

--- a/views_aggregator.module
+++ b/views_aggregator.module
@@ -21,6 +21,17 @@ function views_aggregator_help($path, $arg) {
   }
 }
 
+/** 
+ * Implements hook_config_info().
+ */
+function views_aggregator_config_info() {
+  $prefixes['views_aggregator.settings'] = array(
+    'label' => t('Views Aggregator settings'),
+    'group' => t('Views Aggregator'),
+  );
+  return $prefixes;
+}
+
 /**
  * Implements hook_theme().
  */


### PR DESCRIPTION
This PR solves issue #6 . It removes variable_get, and replaces it with config_get. It adds a config file with three configurations related to numeric fields (separator, decimal sign and precision), and adds an `update_N` function that moves that config file to the active directory for those needed to upgrade to the next version of the module. 